### PR TITLE
Use cryptofeed datafeed

### DIFF
--- a/user_data/config.json
+++ b/user_data/config.json
@@ -8,9 +8,7 @@
   "tradable_balance_ratio": 0.75,
   "timeframe": "5m",
   "exchange": {
-    "name": "binance",
-    "key": "REPLACE_WITH_YOUR_API_KEY",
-    "secret": "REPLACE_WITH_YOUR_API_SECRET",
+    "name": "kucoin",
     "ccxt_config": { "enableRateLimit": true },
     "ccxt_async_config": { "enableRateLimit": true }
   },
@@ -28,6 +26,12 @@
   "unfilledtimeout": {
     "buy": 10,
     "sell": 10
+  },
+  "external_message_consumer": {
+    "enabled": true,
+    "producers": [
+      {"name": "cryptofeed", "url": "ws://localhost:9000"}
+    ]
   },
   "disable_dataframe_checks": true,
   "dataformat_ohlcv": "json",


### PR DESCRIPTION
## Summary
- point bot config to KuCoin instead of Binance
- add external message consumer using the cryptofeed adapter

## Testing
- `python -m freqtrade trade --config user_data/config.json --strategy NoTaStrategy --dry-run --logfile -` *(fails: Network is unreachable to api.kucoin.com)*

------
https://chatgpt.com/codex/tasks/task_e_6897cf1ad38c832cbff31388aa051a9f