### PR TITLE
Use UUID for dry run order IDs

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -7,6 +7,7 @@ import asyncio
 import inspect
 import logging
 import signal
+import uuid
 from collections.abc import Coroutine, Generator
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
@@ -1075,7 +1076,7 @@ class Exchange:
         stop_loss: bool = False,
     ) -> CcxtOrder:
         now = dt_now()
-        order_id = f"dry_run_{side}_{pair}_{now.timestamp()}"
+        order_id = f"dry_run_{side}_{pair}_{uuid.uuid4()}"
         # Rounding here must respect to contract sizes
         _amount = self._contracts_to_amount(
             pair, self.amount_to_precision(pair, self._amount_to_contracts(pair, amount))

--- a/tests/exchange/test_exchange.py
+++ b/tests/exchange/test_exchange.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import uuid
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from random import randint
@@ -1052,6 +1053,7 @@ def test_create_dry_run_order(default_conf, mocker, side, exchange_name, leverag
     )
     assert "id" in order
     assert f"dry_run_{side}_" in order["id"]
+    uuid.UUID(order["id"].rsplit("_", 1)[-1])
     assert order["side"] == side
     assert order["type"] == "limit"
     assert order["symbol"] == "ETH/BTC"


### PR DESCRIPTION
## Summary
- generate dry-run order IDs with `uuid.uuid4()` for uniqueness
- validate dry-run order IDs as UUIDs in tests

## Testing
- `pre-commit run --files freqtrade/exchange/exchange.py tests/exchange/test_exchange.py`
- `pytest tests/exchange/test_exchange.py::test_create_dry_run_order` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6897d5a2f830832c8e139d4929dccb17