### PR TITLE
Fetch interest rate when updating liquidation prices

### DIFF
--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -2359,14 +2359,18 @@ class FreqtradeBot(LoggingMixin):
                 or self.margin_mode == MarginMode.CROSS
             ):
                 # Must also run for partial exits
-                # TODO: Margin will need to use interest_rate as well.
-                # interest_rate = self.exchange.get_interest_rate()
+                interest_rate = 0.0
+                try:
+                    interest_rate = self.exchange.get_interest_rate()
+                except Exception:
+                    logger.debug("Interest rate not available from exchange, defaulting to 0.0")
                 update_liquidation_prices(
                     trade,
                     exchange=self.exchange,
                     wallets=self.wallets,
                     stake_currency=self.config["stake_currency"],
                     dry_run=self.config["dry_run"],
+                    interest_rate=interest_rate,
                 )
             if self.strategy.use_custom_stoploss and trade.is_open:
                 current_rate = self.exchange.get_rate(

--- a/freqtrade/leverage/liquidation_price.py
+++ b/freqtrade/leverage/liquidation_price.py
@@ -17,6 +17,7 @@ def update_liquidation_prices(
     wallets: Wallets,
     stake_currency: str,
     dry_run: bool = False,
+    interest_rate: float = 0.0,
 ):
     """
     Update trade liquidation price in isolated margin mode.
@@ -50,6 +51,7 @@ def update_liquidation_prices(
                         )
                     )
         elif trade:
+            trade.interest_rate = interest_rate
             trade.set_liquidation_price(
                 exchange.get_liquidation_price(
                     pair=trade.pair,


### PR DESCRIPTION
## Summary
- fetch interest rate from exchange when updating a trade after order fill
- store and forward the interest rate to liquidation-price calculations

## Testing
- `pytest tests/leverage/test_update_liquidation_price.py::test_update_liquidation_prices -q` *(fails: No module named 'torch')*
- `pytest tests/freqtradebot/test_freqtradebot.py::test_update_trade_state_sell -q` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6897d5a33400832caef659629d4a958f