### PR TITLE
Add batch script to run main Freqtrade script

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,4 @@
+@echo off
+REM Start Freqtrade main script
+cd /d "%~dp0"
+python freqtrade\main.py %*


### PR DESCRIPTION
## Summary
- add `start.bat` to launch the main Freqtrade script via Python

## Testing
- `pre-commit run --files start.bat`
- `pytest tests/test_main.py` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_689d4cba0190832cb9009a3bc29e7503