### PR TITLE
Install dependencies before launching via start script

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,4 +1,7 @@
 @echo off
 REM Start Freqtrade main script
 cd /d "%~dp0"
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
 python freqtrade\main.py %*
+pause


### PR DESCRIPTION
## Summary
- Upgrade pip and install dependencies in `start.bat` before launching Freqtrade
- Keep console open after run for inspection

## Testing
- `pre-commit run --files start.bat`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'questionary', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689d61817178832ca8afdae87a02ce05