### PR TITLE
Use venv in start script

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,7 +1,12 @@
 @echo off
-REM Start Freqtrade main script
+REM Start Freqtrade main script using local virtual environment
 cd /d "%~dp0"
-python -m pip install --upgrade pip
-python -m pip install -r requirements.txt
-python freqtrade\main.py %*
+
+REM Use Python from the .venv folder
+set "PYTHON=.venv\Scripts\python.exe"
+
+"%PYTHON%" -m pip install --upgrade pip
+"%PYTHON%" -m pip install -r requirements.txt
+"%PYTHON%" -m freqtrade %*
+
 pause


### PR DESCRIPTION
## Summary
- Run start.bat using the local `.venv` Python interpreter
- Install requirements and launch Freqtrade via the virtual environment

## Testing
- `pre-commit run --files start.bat`


------
https://chatgpt.com/codex/tasks/task_e_689d640b5168832c8b0db523c27950c4