### PR TITLE
Default start.bat to trade subcommand

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -7,6 +7,10 @@ set "PYTHON=.venv\Scripts\python.exe"
 
 "%PYTHON%" -m pip install --upgrade pip
 "%PYTHON%" -m pip install -r requirements.txt
-"%PYTHON%" -m freqtrade %*
+if "%~1"=="" (
+    "%PYTHON%" -m freqtrade trade
+) else (
+    "%PYTHON%" -m freqtrade %*
+)
 
 pause


### PR DESCRIPTION
## Summary
- default `start.bat` to run `freqtrade trade` when no arguments are given

## Testing
- `pre-commit run --files start.bat`
- `pytest tests/test_main.py::test_parse_args_version` *(fails: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_689d77939be8832c891195896d012113