### PR TITLE
Add SampleStrategy and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ user_data/*
 !user_data/notebooks
 !user_data/models
 !user_data/freqaimodels
+!user_data/strategies
+!user_data/strategies/**
+!user_data/config.json
 user_data/freqaimodels/*
 user_data/models/*
 user_data/notebooks/*

--- a/user_data/config.json
+++ b/user_data/config.json
@@ -1,0 +1,4 @@
+{
+    "strategy": "SampleStrategy",
+    "strategy_path": "user_data/strategies/"
+}

--- a/user_data/strategies/SampleStrategy.py
+++ b/user_data/strategies/SampleStrategy.py
@@ -1,0 +1,27 @@
+from freqtrade.strategy import IStrategy
+from pandas import DataFrame
+import talib.abstract as ta
+
+
+class SampleStrategy(IStrategy):
+    """Simple moving average crossover strategy."""
+
+    timeframe = '5m'
+    minimal_roi = {"0": 0.10}
+    stoploss = -0.10
+    trailing_stop = False
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe['ema_fast'] = ta.EMA(dataframe, timeperiod=9)
+        dataframe['ema_slow'] = ta.EMA(dataframe, timeperiod=21)
+        return dataframe
+
+    def populate_buy_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[(dataframe['ema_fast'] > dataframe['ema_slow']) &
+                      (dataframe['close'] > dataframe['ema_fast']), 'buy'] = 1
+        return dataframe
+
+    def populate_sell_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[(dataframe['ema_fast'] < dataframe['ema_slow']) &
+                      (dataframe['close'] < dataframe['ema_fast']), 'sell'] = 1
+        return dataframe


### PR DESCRIPTION
## Summary
- add a simple EMA crossover SampleStrategy
- include user config pointing to the new strategy
- track strategies and config in git

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'datasieve')*


------
https://chatgpt.com/codex/tasks/task_e_689d7a9da764832c90cf93579bc43d4c