### PR TITLE
Switch to BinanceUS and update pair list

### DIFF
--- a/user_data/config.json
+++ b/user_data/config.json
@@ -90,7 +90,7 @@
         }
     ],
     "exchange": {
-        "name": "binance",
+        "name": "binanceus",
         "key": "example_key",
         "secret": "example_secret",
         "password": "",
@@ -98,24 +98,14 @@
         "ccxt_config": {},
         "ccxt_async_config": {},
         "pair_whitelist": [
-            "ALGO/BTC",
-            "ATOM/BTC",
-            "BAT/BTC",
-            "BCH/BTC",
-            "BRD/BTC",
-            "EOS/BTC",
-            "ETH/BTC",
-            "IOTA/BTC",
-            "LINK/BTC",
-            "LTC/BTC",
-            "NEO/BTC",
-            "NXS/BTC",
-            "XMR/BTC",
-            "XRP/BTC",
-            "XTZ/BTC"
+            "BTC/USDT",
+            "ETH/USDT",
+            "LTC/USDT",
+            "BCH/USDT",
+            "ADA/USDT"
         ],
         "pair_blacklist": [
-            "DOGE/BTC"
+            "DOGE/USDT"
         ],
         "outdated_offset": 5,
         "markets_refresh_interval": 60


### PR DESCRIPTION
## Summary
- Use BinanceUS exchange in configuration
- Replace pair whitelist with BinanceUS supported pairs

## Testing
- `python -m freqtrade test-pairlist --config user_data/config.json` *(fails: Could not load tickers due to NetworkError. Message: binanceus GET https://api.binance.us/api/v3/exchangeInfo)*

------
https://chatgpt.com/codex/tasks/task_e_689d819563e0832caf051925d23567bb