### PR TITLE
Introduce HybridStrategy and set as default

### DIFF
--- a/user_data/config.json
+++ b/user_data/config.json
@@ -177,7 +177,7 @@
         "heartbeat_interval": 60
     },
     "disable_dataframe_checks": false,
-    "strategy": "SampleStrategy",
+    "strategy": "HybridStrategy",
     "strategy_path": "user_data/strategies/",
     "recursive_strategy_search": false,
     "add_config_files": [],

--- a/user_data/strategies/HybridStrategy.py
+++ b/user_data/strategies/HybridStrategy.py
@@ -1,0 +1,55 @@
+import talib.abstract as ta
+from pandas import DataFrame
+from technical import qtpylib
+
+from freqtrade.strategy import IStrategy
+
+
+class HybridStrategy(IStrategy):
+    """EMA crossover with RSI, volume, and TEMA/Bollinger confirmations."""
+
+    timeframe = "5m"
+    minimal_roi = {
+        "60": 0.01,
+        "30": 0.02,
+        "0": 0.04,
+    }
+    stoploss = -0.10
+    process_only_new_candles = True
+    startup_candle_count: int = 200
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe["ema_fast"] = ta.EMA(dataframe, timeperiod=5)
+        dataframe["ema_slow"] = ta.EMA(dataframe, timeperiod=20)
+        dataframe["rsi"] = ta.RSI(dataframe, timeperiod=14)
+        dataframe["volume_sma"] = ta.SMA(dataframe["volume"], timeperiod=20)
+        dataframe["tema"] = ta.TEMA(dataframe, timeperiod=9)
+        bollinger = qtpylib.bollinger_bands(qtpylib.typical_price(dataframe), window=20, stds=2)
+        dataframe["bb_lowerband"] = bollinger["lower"]
+        dataframe["bb_middleband"] = bollinger["mid"]
+        dataframe["bb_upperband"] = bollinger["upper"]
+        return dataframe
+
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            (
+                qtpylib.crossed_above(dataframe["ema_fast"], dataframe["ema_slow"])
+                & (dataframe["rsi"] < 30)
+                & (dataframe["volume"] > dataframe["volume_sma"])
+                & (dataframe["tema"] <= dataframe["bb_middleband"])
+                & (dataframe["tema"] > dataframe["tema"].shift(1))
+            ),
+            "enter_long",
+        ] = 1
+        return dataframe
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            (
+                qtpylib.crossed_below(dataframe["ema_fast"], dataframe["ema_slow"])
+                | (dataframe["rsi"] > 70)
+                | (dataframe["tema"] < dataframe["tema"].shift(1))
+            ),
+            "exit_long",
+        ] = 1
+        return dataframe


### PR DESCRIPTION
## Summary
- Add configuration to use HybridStrategy by default
- Implement HybridStrategy combining EMA crossover, RSI, volume, TEMA and Bollinger filters

## Testing
- `pre-commit run --files user_data/strategies/HybridStrategy.py user_data/config.json`
- `pytest` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_689d84374d60832cb8da69f4291225ad