### PR TITLE
Configure project for keyless dry-run usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ expect.
 We strongly recommend you to have coding and Python knowledge. Do not
 hesitate to read the source code and understand the mechanism of this bot.
 
+### No API keys required
+
+The provided `user_data/config.json` enables `dry_run` mode and leaves
+exchange and Telegram credentials empty so you can experiment with the bot
+using only free, public data. Add your own API keys once you're ready for
+live trading.
+
 ## Supported Exchange marketplaces
 
 Please read the [exchange specific notes](docs/exchanges.md) to learn about eventual, special configurations needed for each exchange.

--- a/user_data/config.json
+++ b/user_data/config.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://schema.freqtrade.io/schema.json",
     "max_open_trades": 3,
-    "stake_currency": "BTC",
-    "stake_amount": 0.05,
+    "stake_currency": "USDT",
+    "stake_amount": 10,
     "tradable_balance_ratio": 0.99,
     "fiat_display_currency": "USD",
     "amount_reserve_percent": 0.05,
@@ -71,27 +71,16 @@
     },
     "pairlists": [
         {
-            "method": "RemotePairList",
-            "mode": "whitelist",
-            "pairlist_url": "https://example.com/trending-pairs.json",
-            "number_assets": 20,
-            "refresh_period": 1800
+            "method": "StaticPairList",
+            "pairs": ["BTC/USDT", "ETH/USDT"]
         },
-        {
-            "method": "PercentChangePairList",
-            "number_assets": 10,
-            "min_value": 5,
-            "sort_direction": "desc"
-        },
-        {"method": "AgeFilter", "min_days_listed": 10},
-        {"method": "PrecisionFilter"},
         {"method": "PriceFilter", "low_price_ratio": 0.01, "min_price": 0.00000010},
         {"method": "SpreadFilter", "max_spread_ratio": 0.005}
     ],
     "exchange": {
         "name": "binanceus",
-        "key": "example_key",
-        "secret": "example_secret",
+        "key": "",
+        "secret": "",
         "password": "",
         "log_responses": false,
         "ccxt_config": {},
@@ -104,8 +93,8 @@
     },
     "telegram": {
         "enabled": false,
-        "token": "your_telegram_token",
-        "chat_id": "your_telegram_chat_id",
+        "token": "",
+        "chat_id": "",
         "notification_settings": {
             "status": "on",
             "warning": "on",
@@ -138,11 +127,11 @@
         "listen_port": 8080,
         "verbosity": "error",
         "enable_openapi": false,
-        "jwt_secret_key": "somethingrandom",
+        "jwt_secret_key": "",
         "CORS_origins": [],
-        "username": "freqtrader",
-        "password": "SuperSecurePassword",
-        "ws_token": "secret_ws_t0ken."
+        "username": "",
+        "password": "",
+        "ws_token": ""
     },
     "external_message_consumer": {
         "enabled": false,
@@ -151,7 +140,7 @@
             "name": "default",
             "host": "127.0.0.2",
             "port": 8080,
-            "ws_token": "secret_ws_t0ken."
+            "ws_token": ""
           }
         ],
         "wait_timeout": 300,


### PR DESCRIPTION
## Summary
- Simplify sample config for free dry-run usage with empty exchange and telegram credentials
- Document that the default config runs without API keys

## Testing
- `PYTHONPATH=/tmp:$PYTHONPATH pytest tests/test_arguments.py::test_parse_args_default_userdatadir tests/test_configuration.py::test_load_config_missing_attributes -q`

------
https://chatgpt.com/codex/tasks/task_e_689d88ae9d08832c8aa68d7d7a260415