### PR TITLE
Allow RemotePairList to parse JSON without content-type header

### DIFF
--- a/freqtrade/plugins/pairlist/RemotePairList.py
+++ b/freqtrade/plugins/pairlist/RemotePairList.py
@@ -182,20 +182,19 @@ class RemotePairList(IPairList):
 
         try:
             response = requests.get(self._pairlist_url, headers=headers, timeout=self._read_timeout)
-            content_type = response.headers.get("content-type")
             time_elapsed = response.elapsed.total_seconds()
 
-            if "application/json" in str(content_type):
+            try:
                 jsonparse = response.json()
-
+            except ValueError:
+                pairlist = self._handle_error(
+                    f"RemotePairList returned invalid JSON. {self._pairlist_url}"
+                )
+            else:
                 try:
                     pairlist = self.process_json(jsonparse)
                 except Exception as e:
                     pairlist = self._handle_error(f"Failed processing JSON data: {type(e)}")
-            else:
-                pairlist = self._handle_error(
-                    f"RemotePairList is not of type JSON. {self._pairlist_url}"
-                )
 
         except requests.exceptions.RequestException:
             pairlist = self._handle_error(

--- a/tests/plugins/test_remotepairlist.py
+++ b/tests/plugins/test_remotepairlist.py
@@ -61,6 +61,7 @@ def test_gen_pairlist_with_local_file(mocker, rpl_config):
 def test_fetch_pairlist_mock_response_html(mocker, rpl_config):
     mock_response = MagicMock()
     mock_response.headers = {"content-type": "text/html"}
+    mock_response.json.side_effect = ValueError("No JSON object could be decoded")
 
     rpl_config["pairlists"] = [
         {
@@ -82,7 +83,7 @@ def test_fetch_pairlist_mock_response_html(mocker, rpl_config):
         exchange, pairlistmanager, rpl_config, rpl_config["pairlists"][0], 0
     )
 
-    with pytest.raises(OperationalException, match="RemotePairList is not of type JSON."):
+    with pytest.raises(OperationalException, match="RemotePairList returned invalid JSON"):
         remote_pairlist.fetch_pairlist()
 
 
@@ -156,7 +157,7 @@ def test_remote_pairlist_init_no_number_assets(mocker, rpl_config):
         get_patched_freqtradebot(mocker, rpl_config)
 
 
-def test_fetch_pairlist_mock_response_valid(mocker, rpl_config):
+def test_fetch_pairlist_mock_response_text_plain_valid(mocker, rpl_config):
     rpl_config["pairlists"] = [
         {
             "method": "RemotePairList",
@@ -175,7 +176,7 @@ def test_fetch_pairlist_mock_response_valid(mocker, rpl_config):
         "refresh_period": 60,
     }
 
-    mock_response.headers = {"content-type": "application/json"}
+    mock_response.headers = {"content-type": "text/plain"}
 
     mock_response.elapsed.total_seconds.return_value = 0.4
     mocker.patch(


### PR DESCRIPTION
## Summary
- Attempt to parse RemotePairList responses as JSON regardless of `content-type`
- Add tests covering valid JSON served with `text/plain`

## Testing
- `pytest tests/plugins/test_remotepairlist.py::test_fetch_pairlist_mock_response_html tests/plugins/test_remotepairlist.py::test_fetch_pairlist_mock_response_text_plain_valid -q`


------
https://chatgpt.com/codex/tasks/task_e_689d8db050a0832ca8d42372b8164abd