### PR TITLE
feat: set terminal header in start script

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,4 +1,5 @@
 @echo off
+title FreqTrade
 REM Start Freqtrade main script using local virtual environment
 cd /d "%~dp0"
 


### PR DESCRIPTION
## Summary
- Set Windows start script window title to "FreqTrade" for clearer terminal headers

## Testing
- `pytest -q` *(fails: No module named 'numpy')*
- `pip install -r requirements-dev.txt` *(fails: Failed building wheel for ta-lib)*

------
https://chatgpt.com/codex/tasks/task_e_689d94c33ba8832cbd6bbb714a388b51