### PR TITLE
Add batch script to submit dryrun trades via PR

### DIFF
--- a/submit_trades_pr.bat
+++ b/submit_trades_pr.bat
@@ -1,0 +1,30 @@
+@echo off
+setlocal
+
+REM Create a pull request with tradesv3.dryrun sqlite files in this folder
+
+set "BRANCH=trade-sqlite-upload"
+set "BASE=main"
+set "FILE_PATTERN=tradesv3.dryrun*.sqlite"
+
+cd /d "%~dp0"
+
+git checkout -B "%BRANCH%" || goto :eof
+
+for %%F in (%FILE_PATTERN%) do (
+    if exist "%%F" git add "%%F"
+)
+
+git commit -m "Add tradesv3 dryrun sqlite data" || goto :eof
+
+git push -u origin "%BRANCH%" || goto :eof
+
+gh pr create ^
+    --title "Add tradesv3 dryrun sqlite data" ^
+    --body  "Uploading tradesv3.dryrun sqlite files for review and improvement." ^
+    --base  "%BASE%" ^
+    --head  "%BRANCH%" || goto :eof
+
+echo.
+echo Pull request submitted.
+endlocal


### PR DESCRIPTION
## Summary
- add Windows batch script to commit tradesv3 dryrun sqlite files and open a pull request

## Testing
- `pre-commit run --files submit_trades_pr.bat`
- `pytest tests/persistence/test_trade_fromjson.py` *(fails: ModuleNotFoundError: No module named 'jsonschema')*

------
https://chatgpt.com/codex/tasks/task_e_689e6c2310cc832ca4c587feb601faad