### PR TITLE
fix: force-add sqlite files in submit script

### DIFF
--- a/submit_trades_pr.bat
+++ b/submit_trades_pr.bat
@@ -12,7 +12,7 @@ cd /d "%~dp0"
 git checkout -B "%BRANCH%" || goto :eof
 
 for %%F in (%FILE_PATTERN%) do (
-    if exist "%%F" git add "%%F"
+    if exist "%%F" git add -f "%%F"
 )
 
 git commit -m "Add tradesv3 dryrun sqlite data" || goto :eof


### PR DESCRIPTION
## Summary
- force-add `tradesv3.dryrun*.sqlite` files when creating PR

## Testing
- `pre-commit run --files submit_trades_pr.bat`
- `pytest tests/test_misc.py` *(fails: ModuleNotFoundError: No module named 'cachetools')*


------
https://chatgpt.com/codex/tasks/task_e_689e730b33d4832cac12eb933ef4857b