### PR TITLE
Ensure autoupdate resets repository to main

### DIFF
--- a/autoupdate.bat
+++ b/autoupdate.bat
@@ -5,6 +5,9 @@ cd /d "%~dp0"
 echo Fetching latest changes...
 git fetch --all
 
+git checkout main
+git reset --hard origin/main
+
 echo Rebasing local changes onto remote...
 git pull --rebase
 


### PR DESCRIPTION
## Summary
- Reset repo to `origin/main` during `autoupdate.bat` to restore tracked files

## Testing
- `git fetch --all`
- `git checkout main`
- `git reset --hard origin/main`
- `git pull --rebase`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_689e9943e828832c88b2b1c6a849460a