### PR TITLE
chore: switch autoupdate script to develop

### DIFF
--- a/autoupdate.bat
+++ b/autoupdate.bat
@@ -5,8 +5,8 @@ cd /d "%~dp0"
 echo Fetching latest changes...
 git fetch --all
 
-git checkout main
-git reset --hard origin/main
+git checkout develop
+git reset --hard origin/develop
 
 echo Rebasing local changes onto remote...
 git pull --rebase


### PR DESCRIPTION
## Summary
- update autoupdate.bat to use the develop branch instead of main

## Testing
- `python -m pre_commit run --files autoupdate.bat`
- `bash autoupdate.bat` (after modifying a tracked file)


------
https://chatgpt.com/codex/tasks/task_e_689e9c71fba4832cac3b8869ff798bd8