### PR TITLE
Reduce startup candle requirement for HybridStrategy

### DIFF
--- a/user_data/strategies/HybridStrategy.py
+++ b/user_data/strategies/HybridStrategy.py
@@ -16,7 +16,7 @@ class HybridStrategy(IStrategy):
     }
     stoploss = -0.10
     process_only_new_candles = True
-    startup_candle_count: int = 200
+    startup_candle_count: int = 50
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         dataframe["ema_fast"] = ta.EMA(dataframe, timeperiod=5)


### PR DESCRIPTION
## Summary
- Align HybridStrategy's `startup_candle_count` with longest indicator period

## Testing
- `python -m freqtrade backtesting --config user_data/config.json --strategy HybridStrategy --timeframe 5m --timerange 20220101-20220102` *(fails: Error in reload_markets due to ExchangeNotAvailable: binanceus GET https://api.binance.us/api/v3/exchangeInfo)*

------
https://chatgpt.com/codex/tasks/task_e_689eaa9caac0832cb39863ced773beee