### PR TITLE
Increase RSI threshold in HybridStrategy

### DIFF
--- a/user_data/strategies/HybridStrategy.py
+++ b/user_data/strategies/HybridStrategy.py
@@ -34,7 +34,7 @@ class HybridStrategy(IStrategy):
         dataframe.loc[
             (
                 qtpylib.crossed_above(dataframe["ema_fast"], dataframe["ema_slow"])
-                & (dataframe["rsi"] < 30)
+                & (dataframe["rsi"] < 40)
                 & (dataframe["volume"] > dataframe["volume_sma"])
                 & (dataframe["tema"] <= dataframe["bb_middleband"])
                 & (dataframe["tema"] > dataframe["tema"].shift(1))


### PR DESCRIPTION
## Summary
- raise RSI oversold trigger in `HybridStrategy` from 30 to 40 for earlier entries

## Testing
- `python -m py_compile user_data/strategies/HybridStrategy.py`
- `python -m freqtrade backtesting --config user_data/config.json --datadir tests/testdata --pairs XLM/BTC --timeframe 5m --strategy HybridStrategy --timerange 20180110-20180130` *(fails: Error in reload_markets due to ExchangeNotAvailable)*
- `python - <<'PY'
...script evaluating signal counts...
PY`

------
https://chatgpt.com/codex/tasks/task_e_689eac3a0d34832ca81e25e9d300693b