### PR TITLE
Enable trailing stop and ATR-based stoploss

### DIFF
--- a/user_data/config.json
+++ b/user_data/config.json
@@ -13,10 +13,10 @@
     "dry_run_wallet": 1000,
     "cancel_open_orders_on_exit": false,
     "timeframe": "5m",
-    "trailing_stop": false,
-    "trailing_stop_positive": 0.005,
-    "trailing_stop_positive_offset": 0.0051,
-    "trailing_only_offset_is_reached": false,
+    "trailing_stop": true,
+    "trailing_stop_positive": 0.01,
+    "trailing_stop_positive_offset": 0.02,
+    "trailing_only_offset_is_reached": true,
     "use_exit_signal": true,
     "exit_profit_only": false,
     "exit_profit_offset": 0.0,
@@ -25,10 +25,11 @@
     "trading_mode": "spot",
     "margin_mode": "",
     "minimal_roi": {
-        "40":  0.0,
-        "30":  0.01,
-        "20":  0.02,
-        "0":  0.04
+        "0": 0.05,
+        "15": 0.03,
+        "30": 0.02,
+        "60": 0.01,
+        "120": 0.0
     },
     "stoploss": -0.10,
     "unfilledtimeout": {

--- a/user_data/strategies/HybridStrategy.py
+++ b/user_data/strategies/HybridStrategy.py
@@ -1,6 +1,8 @@
 import talib.abstract as ta
 from pandas import DataFrame
 from technical import qtpylib
+from freqtrade.persistence import Trade
+from datetime import datetime
 
 from freqtrade.strategy import IStrategy
 
@@ -10,9 +12,11 @@ class HybridStrategy(IStrategy):
 
     timeframe = "5m"
     minimal_roi = {
-        "60": 0.01,
+        "0": 0.05,
+        "15": 0.03,
         "30": 0.02,
-        "0": 0.04,
+        "60": 0.01,
+        "120": 0.0,
     }
     stoploss = -0.10
     process_only_new_candles = True
@@ -24,6 +28,7 @@ class HybridStrategy(IStrategy):
         dataframe["rsi"] = ta.RSI(dataframe, timeperiod=14)
         dataframe["volume_sma"] = ta.SMA(dataframe["volume"], timeperiod=20)
         dataframe["tema"] = ta.TEMA(dataframe, timeperiod=9)
+        dataframe["atr"] = ta.ATR(dataframe, timeperiod=14)
         bollinger = qtpylib.bollinger_bands(qtpylib.typical_price(dataframe), window=20, stds=2)
         dataframe["bb_lowerband"] = bollinger["lower"]
         dataframe["bb_middleband"] = bollinger["mid"]
@@ -53,3 +58,23 @@ class HybridStrategy(IStrategy):
             "exit_long",
         ] = 1
         return dataframe
+
+    def custom_stoploss(
+        self,
+        pair: str,
+        trade: Trade,
+        current_time: datetime,
+        current_rate: float,
+        current_profit: float,
+        **kwargs,
+    ) -> float:
+        dataframe, _ = self.dp.get_analyzed_dataframe(pair, self.timeframe)
+        if dataframe is None or dataframe.empty:
+            return self.stoploss
+
+        atr = dataframe["atr"].iloc[-1]
+        if atr is None or current_rate == 0:
+            return self.stoploss
+
+        atr_stop = -atr / current_rate
+        return max(self.stoploss, atr_stop)


### PR DESCRIPTION
## Summary
- enable trailing stop with tiered ROI targets
- add ATR-based custom stoploss to HybridStrategy

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'joblib')*

------
https://chatgpt.com/codex/tasks/task_e_689eaf12aa30832ca67957839d5b2405