### PR TITLE
Remove ROI and stoploss config duplicates

### DIFF
--- a/user_data/config.json
+++ b/user_data/config.json
@@ -24,14 +24,6 @@
     "ignore_buying_expired_candle_after": 300,
     "trading_mode": "spot",
     "margin_mode": "",
-    "minimal_roi": {
-        "0": 0.05,
-        "15": 0.03,
-        "30": 0.02,
-        "60": 0.01,
-        "120": 0.0
-    },
-    "stoploss": -0.10,
     "unfilledtimeout": {
         "entry": 10,
         "exit": 10,

--- a/user_data/strategies/HybridStrategy.py
+++ b/user_data/strategies/HybridStrategy.py
@@ -9,9 +9,14 @@ from freqtrade.strategy import IStrategy
 
 
 class HybridStrategy(IStrategy):
-    """EMA crossover with RSI, volume, and TEMA/Bollinger confirmations."""
+    """EMA crossover with RSI, volume, and TEMA/Bollinger confirmations.
+
+    ROI and stoploss are defined within this strategy to keep it self-contained.
+    user_data/config.json should not define these parameters.
+    """
 
     timeframe = "5m"
+    # Minimal ROI mapping.
     minimal_roi = {
         "0": 0.05,
         "15": 0.03,
@@ -19,6 +24,7 @@ class HybridStrategy(IStrategy):
         "60": 0.01,
         "120": 0.0,
     }
+    # Initial stoploss.
     stoploss = -0.10
     process_only_new_candles = True
     startup_candle_count: int = 50


### PR DESCRIPTION
## Summary
- Keep ROI and stoploss in `HybridStrategy` and remove duplicates from `user_data/config.json`
- Clarify in strategy docs that ROI and stoploss are defined there

## Testing
- `python -m py_compile user_data/strategies/HybridStrategy.py`
- `python - <<'PY' 2>/tmp/err.log
from freqtrade.configuration import Configuration
from freqtrade.enums import RunMode
from freqtrade.resolvers.strategy_resolver import StrategyResolver

config = Configuration.from_files(["user_data/config.json"])
config["runmode"] = RunMode.DRY_RUN
config["strategy"] = "HybridStrategy"
config["strategy_path"] = "user_data/strategies/"
strategy = StrategyResolver.load_strategy(config)
print("RESULT", strategy.minimal_roi, strategy.stoploss)
PY
` *(failed: Could not load markets due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_689ec21149d4832c93ba20816b2181c4