### PR TITLE
feat: allow configurable heartbeat log level

### DIFF
--- a/build_helpers/schema.json
+++ b/build_helpers/schema.json
@@ -1063,6 +1063,20 @@
           "description": "Minimum loop duration for one bot iteration in seconds.",
           "type": "integer"
         },
+        "heartbeat_interval": {
+          "description": "Print heartbeat message every N seconds. Set to 0 to disable heartbeat messages.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "heartbeat_loglevel": {
+          "description": "Log level for heartbeat messages. Set to 'none' to disable logging.",
+          "type": "string",
+          "enum": [
+            "info",
+            "debug",
+            "none"
+          ]
+        },
         "interval": {
           "description": "Interval time in seconds.",
           "type": "integer"

--- a/config_examples/config_full.example.json
+++ b/config_examples/config_full.example.json
@@ -185,7 +185,8 @@
     "force_entry_enable": false,
     "internals": {
         "process_throttle_secs": 5,
-        "heartbeat_interval": 60
+        "heartbeat_interval": 60,
+        "heartbeat_loglevel": "info"
     },
     "disable_dataframe_checks": false,
     "strategy": "SampleStrategy",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -270,6 +270,7 @@ Mandatory parameters are marked as **Required**, which means that they are requi
 | `disable_dataframe_checks` | Disable checking the OHLCV dataframe returned from the strategy methods for correctness. Only use when intentionally changing the dataframe and understand what you are doing. [Strategy Override](#parameters-in-the-strategy).<br> *Defaults to `False`*. <br> **Datatype:** Boolean
 | `internals.process_throttle_secs` | Set the process throttle, or minimum loop duration for one bot iteration loop. Value in second. <br>*Defaults to `5` seconds.* <br> **Datatype:** Positive Integer
 | `internals.heartbeat_interval` | Print heartbeat message every N seconds. Set to 0 to disable heartbeat messages. <br>*Defaults to `60` seconds.* <br> **Datatype:** Positive Integer or 0
+| `internals.heartbeat_loglevel` | Log level for heartbeat messages. Set to `none` to disable logging while keeping the heartbeat interval active. <br>*Defaults to `info`.* <br> **Datatype:** Enum, either `info`, `debug` or `none`
 | `internals.sd_notify` | Enables use of the sd_notify protocol to tell systemd service manager about changes in the bot state and issue keep-alive pings. See [here](advanced-setup.md#configure-the-bot-running-as-a-systemd-service) for more details. <br> **Datatype:** Boolean
 | `strategy` | **Required** Defines Strategy class to use. Recommended to be set via `--strategy NAME`. <br> **Datatype:** ClassName
 | `strategy_path` | Adds an additional strategy lookup path (must be a directory). <br> **Datatype:** String

--- a/freqtrade/config_schema/config_schema.py
+++ b/freqtrade/config_schema/config_schema.py
@@ -730,6 +730,21 @@ CONF_SCHEMA = {
                     "description": "Minimum loop duration for one bot iteration in seconds.",
                     "type": "integer",
                 },
+                "heartbeat_interval": {
+                    "description": (
+                        "Print heartbeat message every N seconds. "
+                        "Set to 0 to disable heartbeat messages."
+                    ),
+                    "type": "integer",
+                    "minimum": 0,
+                },
+                "heartbeat_loglevel": {
+                    "description": (
+                        "Log level for heartbeat messages. Set to 'none' to disable logging."
+                    ),
+                    "type": "string",
+                    "enum": ["info", "debug", "none"],
+                },
                 "interval": {
                     "description": "Interval time in seconds.",
                     "type": "integer",

--- a/freqtrade/worker.py
+++ b/freqtrade/worker.py
@@ -57,6 +57,11 @@ class Worker:
         internals_config = self._config.get("internals", {})
         self._throttle_secs = internals_config.get("process_throttle_secs", PROCESS_THROTTLE_SECS)
         self._heartbeat_interval = internals_config.get("heartbeat_interval", 60)
+        heartbeat_loglevel = internals_config.get("heartbeat_loglevel", "INFO")
+        heartbeat_loglevel = str(heartbeat_loglevel).lower()
+        if heartbeat_loglevel not in ("info", "debug", "none"):
+            heartbeat_loglevel = "info"
+        self._heartbeat_loglevel = None if heartbeat_loglevel == "none" else heartbeat_loglevel
 
         self._sd_notify = (
             sdnotify.SystemdNotifier()
@@ -128,14 +133,15 @@ class Worker:
                 timeframe_offset=1,
             )
 
-        if self._heartbeat_interval:
+        if self._heartbeat_interval and self._heartbeat_loglevel:
             now = time.time()
             if (now - self._heartbeat_msg) > self._heartbeat_interval:
                 version = __version__
                 strategy_version = self.freqtrade.strategy.version()
                 if strategy_version is not None:
                     version += ", strategy_version: " + strategy_version
-                logger.info(
+                log_func = getattr(logger, self._heartbeat_loglevel)
+                log_func(
                     f"Bot heartbeat. PID={getpid()}, version='{version}', state='{state.name}'"
                 )
                 self._heartbeat_msg = now

--- a/tests/freqtradebot/test_worker.py
+++ b/tests/freqtradebot/test_worker.py
@@ -257,3 +257,31 @@ def test_worker_heartbeat_stopped(default_conf, mocker, caplog):
     worker._heartbeat_msg -= 70
     worker._worker(old_state=State.STOPPED)
     assert log_has_re(message, caplog)
+
+
+def test_worker_heartbeat_debug(default_conf, mocker, caplog):
+    message = r"Bot heartbeat\. PID=.*state='RUNNING'"
+    default_conf["internals"]["heartbeat_loglevel"] = "debug"
+
+    mock_throttle = MagicMock()
+    mocker.patch("freqtrade.worker.Worker._throttle", mock_throttle)
+    caplog.set_level(logging.DEBUG)
+    worker = get_patched_worker(mocker, default_conf)
+
+    worker.freqtrade.state = State.RUNNING
+    worker._worker(old_state=State.STOPPED)
+    assert log_has_re(message, caplog)
+
+
+def test_worker_heartbeat_disabled(default_conf, mocker, caplog):
+    message = r"Bot heartbeat\. PID=.*state='RUNNING'"
+    default_conf["internals"]["heartbeat_loglevel"] = "none"
+
+    mock_throttle = MagicMock()
+    mocker.patch("freqtrade.worker.Worker._throttle", mock_throttle)
+    caplog.set_level(logging.DEBUG)
+    worker = get_patched_worker(mocker, default_conf)
+
+    worker.freqtrade.state = State.RUNNING
+    worker._worker(old_state=State.STOPPED)
+    assert not log_has_re(message, caplog)

--- a/user_data/config.json
+++ b/user_data/config.json
@@ -152,7 +152,8 @@
     "force_entry_enable": false,
     "internals": {
         "process_throttle_secs": 5,
-        "heartbeat_interval": 60
+        "heartbeat_interval": 60,
+        "heartbeat_loglevel": "info"
     },
     "disable_dataframe_checks": false,
     "strategy": "HybridStrategy",


### PR DESCRIPTION
## Summary
- add `heartbeat_loglevel` option to control heartbeat logging verbosity
- document heartbeat logging level
- test debug and disabled heartbeat logging

## Testing
- `pre-commit run --files freqtrade/worker.py freqtrade/config_schema/config_schema.py config_examples/config_full.example.json user_data/config.json docs/configuration.md tests/freqtradebot/test_worker.py`
- `pytest tests/freqtradebot/test_worker.py -k heartbeat`


------
https://chatgpt.com/codex/tasks/task_e_689f70e6dbb0832ca78f01eb8a889410