### PR TITLE
Summarize pair removal logging

### DIFF
--- a/freqtrade/plugins/pairlist/SpreadFilter.py
+++ b/freqtrade/plugins/pairlist/SpreadFilter.py
@@ -5,7 +5,7 @@ Spread pair list filter
 import logging
 
 from freqtrade.exceptions import OperationalException
-from freqtrade.exchange.exchange_types import Ticker
+from freqtrade.exchange.exchange_types import Ticker, Tickers
 from freqtrade.plugins.pairlist.IPairList import IPairList, PairlistParameter, SupportsBacktesting
 
 
@@ -26,6 +26,10 @@ class SpreadFilter(IPairList):
                 f"{self.name} requires exchange to have bid/ask data for tickers, "
                 "which is not available for the selected exchange / trading mode."
             )
+
+        # Lists used to collect removed pairs during a refresh cycle
+        self._removed_spread: list[str] = []
+        self._removed_invalid: list[str] = []
 
     @property
     def needstickers(self) -> bool:
@@ -69,15 +73,37 @@ class SpreadFilter(IPairList):
         if ticker and "bid" in ticker and "ask" in ticker and ticker["ask"] and ticker["bid"]:
             spread = 1 - ticker["bid"] / ticker["ask"]
             if spread > self._max_spread_ratio:
-                self.log_once(
-                    f"Removed {pair} from whitelist, because spread "
-                    f"{spread:.3%} > {self._max_spread_ratio:.3%}",
-                    logger.info,
-                )
+                self._removed_spread.append(pair)
                 return False
             else:
                 return True
-        self.log_once(
-            f"Removed {pair} from whitelist due to invalid ticker data: {ticker}", logger.info
-        )
+        self._removed_invalid.append(pair)
         return False
+
+    def filter_pairlist(self, pairlist: list[str], tickers: Tickers) -> list[str]:
+        """Filters the pairlist and logs a summary of removed pairs."""
+        # Reset removal trackers for this refresh cycle
+        self._removed_spread = []
+        self._removed_invalid = []
+
+        pairlist = super().filter_pairlist(pairlist, tickers)
+
+        if self._removed_spread:
+            pairs = ", ".join(sorted(self._removed_spread))
+            self.log_once(
+                (
+                    f"Removed {len(self._removed_spread)} pairs from whitelist due to high spread: "
+                    f"{pairs}"
+                ),
+                logger.info,
+            )
+        if self._removed_invalid:
+            pairs = ", ".join(sorted(self._removed_invalid))
+            msg = (
+                "Removed "
+                f"{len(self._removed_invalid)} pairs from whitelist due to invalid ticker data: "
+                f"{pairs}"
+            )
+            self.log_once(msg, logger.info)
+
+        return pairlist

--- a/freqtrade/plugins/pairlistmanager.py
+++ b/freqtrade/plugins/pairlistmanager.py
@@ -163,10 +163,14 @@ class PairListManager(LoggingMixin):
             logger.error(f"Pair blacklist contains an invalid Wildcard: {err}")
             return []
         log_once = partial(self.log_once, logmethod=logmethod)
+        removed_pairs: list[str] = []
         for pair in pairlist.copy():
             if pair in blacklist:
-                log_once(f"Pair {pair} in your blacklist. Removing it from whitelist...")
+                removed_pairs.append(pair)
                 pairlist.remove(pair)
+        if removed_pairs:
+            pairs = ", ".join(sorted(removed_pairs))
+            log_once(f"Removed blacklisted pairs from whitelist: {pairs}")
         return pairlist
 
     def verify_whitelist(

--- a/tests/plugins/test_pairlist.py
+++ b/tests/plugins/test_pairlist.py
@@ -277,7 +277,7 @@ def test_remove_logs_for_pairs_already_in_blacklist(mocker, markets, static_pl_c
     assert set(whitelist) == set(freqtrade.pairlists.whitelist)
     assert static_pl_conf["exchange"]["pair_blacklist"] == freqtrade.pairlists.blacklist
     # Ensure that log message wasn't generated.
-    assert not log_has("Pair BLK/BTC in your blacklist. Removing it from whitelist...", caplog)
+    assert not log_has("Removed blacklisted pairs from whitelist: BLK/BTC", caplog)
 
     for _ in range(3):
         new_whitelist = freqtrade.pairlists.verify_blacklist(
@@ -285,7 +285,7 @@ def test_remove_logs_for_pairs_already_in_blacklist(mocker, markets, static_pl_c
         )
         # Ensure that the pair is removed from the white list, and properly logged.
         assert set(whitelist) == set(new_whitelist)
-    assert num_log_has("Pair BLK/BTC in your blacklist. Removing it from whitelist...", caplog) == 1
+    assert num_log_has("Removed blacklisted pairs from whitelist: BLK/BTC", caplog) == 1
 
 
 def test_refresh_pairlist_dynamic(mocker, shitcoinmarkets, tickers, whitelist_conf):
@@ -1757,7 +1757,7 @@ def test_spreadfilter_invalid_data(mocker, default_conf, markets, tickers, caplo
     mocker.patch.multiple(EXMS, get_tickers=tickers)
 
     ftbot.pairlists.refresh_pairlist()
-    assert log_has_re(r"Removed .* invalid ticker data.*", caplog)
+    assert log_has_re(r"Removed \d+ pairs from whitelist due to invalid ticker data: .*", caplog)
 
     assert len(ftbot.pairlists.whitelist) == 2
 


### PR DESCRIPTION
## Summary
- aggregate high-spread pair removals in SpreadFilter and log once per refresh
- summarize blacklist removals in PairListManager
- adjust tests for aggregated logging behavior

## Testing
- `pre-commit run --files freqtrade/plugins/pairlist/SpreadFilter.py freqtrade/plugins/pairlistmanager.py tests/plugins/test_pairlist.py`
- `pytest tests/plugins/test_pairlist.py -k "test_remove_logs_for_pairs_already_in_blacklist or test_spreadfilter_invalid_data" -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_689f75e244fc832ca4a8b8d4420b78c2