### PR TITLE
Adjust spread filter for early testing

### DIFF
--- a/docs/includes/pairlists.md
+++ b/docs/includes/pairlists.md
@@ -543,6 +543,9 @@ To shuffle on every iteration, set `"shuffle_frequency"` to `"iteration"` instea
 
 Removes pairs that have a difference between asks and bids above the specified ratio, `max_spread_ratio` (defaults to `0.005`).
 
+!!! Note
+    During early testing, a higher `max_spread_ratio` (for example `0.01`–`0.02`) or using a `StaticPairList` instead of `SpreadFilter` can keep more pairs available for trading. Wider spreads, however, increase the chance of slippage, meaning orders may fill at less favorable prices.
+
 Example:
 
 If `DOGE/BTC` maximum bid is 0.00000026 and minimum ask is 0.00000027, the ratio is calculated as: `1 - bid/ask ~= 0.037` which is `> 0.005` and this pair will be filtered out.

--- a/user_data/config.json
+++ b/user_data/config.json
@@ -71,7 +71,7 @@
             "refresh_period": 60
         },
         {"method": "PriceFilter", "low_price_ratio": 0.01, "min_price": 0.00000010},
-        {"method": "SpreadFilter", "max_spread_ratio": 0.005}
+        {"method": "SpreadFilter", "max_spread_ratio": 0.02}
     ],
     "exchange": {
         "name": "binanceus",


### PR DESCRIPTION
## Summary
- Raise `max_spread_ratio` to 0.02 in sample config for wider pair coverage during initial testing
- Document that larger spreads or using a static pairlist can increase slippage risk

## Testing
- `pytest tests/plugins/test_pairlist.py -k SpreadFilter -q --maxfail=1` *(fails: freqtrade.exceptions.OperationalException: Impossible to load Strategy 'StrategyTestV3'. This class does not exist or contains Python code errors.)*


------
https://chatgpt.com/codex/tasks/task_e_689f7effed40832c9c0c5298c436581a